### PR TITLE
Specify raven version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-raven
+raven==6.1.0


### PR DESCRIPTION
As of version 6.2.0, raven is encountering problems while importing contextlib2. 
In order to make continuous integration more transparent, a field tested raven version is specified in the requirements file, instead of taking the latest one. 