### PR TITLE
Upgrade to new sentry SDK for python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ You must provide a Sentry DSN::
 
     sentry.dsn = https://xxxxxx:xxxxxx@sentry.domain.com/1
 
-You can see a full list of supported options for the Sentry client on the `official Raven documentation`_.
+You can see a full list of supported options for the Sentry client on the `official Sentry documentation`_.
 
 If you want Sentry to record your log messages, you can turn it on adding the following options::
 
@@ -55,5 +55,5 @@ The configuration also supports env vars named like the `ckanext-envvars`_ exten
 
 
 .. _Sentry: http://getsentry.com/
-.. _official Raven documentation: http://raven.readthedocs.org/en/latest/advanced.html#configuring-the-client
+.. _official Sentry documentation: https://docs.sentry.io/error-reporting/configuration/?platform=python
 .. _ckanext-envvars: https://github.com/okfn/ckanext-envvars

--- a/ckanext/sentry/plugins.py
+++ b/ckanext/sentry/plugins.py
@@ -4,8 +4,9 @@ from __future__ import unicode_literals
 import os
 import logging
 
-from raven.contrib.pylons import Sentry
-from raven.handlers.logging import SentryHandler
+import sentry_sdk
+from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
+from sentry_sdk.integrations.logging import SentryHandler
 
 
 from ckan import plugins
@@ -44,7 +45,9 @@ class SentryPlugin(plugins.SingletonPlugin):
             self._configure_logging(config)
 
         log.debug('Adding Sentry middleware...')
-        return Sentry(app, config)
+        sentry_sdk.init(dsn=config.get('sentry.dsn'))
+        sentry = SentryWsgiMiddleware(app)
+        return app
 
     def _configure_logging(self, config):
         '''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-raven==6.1.0
+sentry-sdk==0.7.10

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     namespace_packages=['ckanext'],
     include_package_data=True,
     zip_safe=False,
-    install_requires=['raven'],
+    install_requires=['sentry_sdk'],
     entry_points={
         'ckan.plugins': [
             'sentry = ckanext.sentry.plugins:SentryPlugin',


### PR DESCRIPTION
We started getting errors and sentry stopped reporting CKAN exceptions:
```
<urlopen error [Errno 104] Connection reset by peer> (url: https://sentry/api/2/store/)
Traceback (most recent call last):
  File "/usr/lib/ckan/default/lib64/python2.7/dist-packages/raven/transport/threaded.py", line 165, in send_sync
    super(ThreadedHTTPTransport, self).send(url, data, headers)
  File "/usr/lib/ckan/default/lib64/python2.7/dist-packages/raven/transport/http.py", line 43, in send
    ca_certs=self.ca_certs,
  File "/usr/lib/ckan/default/lib64/python2.7/dist-packages/raven/utils/http.py", line 66, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib64/python2.7/urllib2.py", line 429, in open
    response = self._open(req, data)
  File "/usr/lib64/python2.7/urllib2.py", line 447, in _open
    '_open', req)
  File "/usr/lib64/python2.7/urllib2.py", line 407, in _call_chain
    result = func(*args)
  File "/usr/lib/ckan/default/lib64/python2.7/dist-packages/raven/utils/http.py", line 46, in https_open
    return self.do_open(ValidHTTPSConnection, req)
  File "/usr/lib64/python2.7/urllib2.py", line 1200, in do_open
    raise URLError(err)
URLError: <urlopen error [Errno 104] Connection reset by peer>
```

Upgrading from raven to the new sentry SDK for python https://github.com/getsentry/sentry-python resumed exceptions being reported.