### PR TITLE
Upgrade to new sentry-sdk

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ You must provide a Sentry DSN::
 
     sentry.dsn = https://xxxxxx:xxxxxx@sentry.domain.com/1
 
-You can see a full list of supported options for the Sentry client on the `official Raven documentation`_.
+You can see a full list of supported options for the Sentry client on the `official Sentry documentation`_.
 
 If you want Sentry to record your log messages, you can turn it on adding the following options::
 
@@ -55,5 +55,5 @@ The configuration also supports env vars named like the `ckanext-envvars`_ exten
 
 
 .. _Sentry: http://getsentry.com/
-.. _official Raven documentation: http://raven.readthedocs.org/en/latest/advanced.html#configuring-the-client
+.. _official Sentry documentation: https://docs.sentry.io/error-reporting/configuration/?platform=python
 .. _ckanext-envvars: https://github.com/okfn/ckanext-envvars

--- a/ckanext/sentry/plugins.py
+++ b/ckanext/sentry/plugins.py
@@ -5,7 +5,7 @@ import os
 import logging
 
 import sentry_sdk
-from sentry_sdk.integrations.logging import SentryHandler
+from sentry_sdk.integrations.logging import LoggingIntegration, SentryHandler
 from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.rq import RqIntegration
 
@@ -46,9 +46,14 @@ class SentryPlugin(plugins.SingletonPlugin):
             self._configure_logging(config)
 
         log.debug('Adding Sentry middleware...')
+        sentry_log_level = config.get('sentry.log_level', logging.INFO)
         sentry_sdk.init(
             dsn=config.get('sentry.dsn'),
-            integrations=[FlaskIntegration(), RqIntegration()]
+            integrations=[
+                FlaskIntegration(),
+                LoggingIntegration(level=sentry_log_level),
+                RqIntegration()
+            ]
         )
         return app
 

--- a/ckanext/sentry/plugins.py
+++ b/ckanext/sentry/plugins.py
@@ -56,7 +56,7 @@ class SentryPlugin(plugins.SingletonPlugin):
         Based on @rshk work on
         https://github.com/opendatatrentino/ckanext-sentry
         '''
-        handler = SentryHandler(config.get('sentry.dsn'))
+        handler = SentryHandler()
         handler.setLevel(logging.NOTSET)
 
         loggers = ['', 'ckan', 'ckanext', 'sentry.errors']

--- a/ckanext/sentry/plugins.py
+++ b/ckanext/sentry/plugins.py
@@ -5,8 +5,9 @@ import os
 import logging
 
 import sentry_sdk
-from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from sentry_sdk.integrations.logging import SentryHandler
+from sentry_sdk.integrations.flask import FlaskIntegration
+from sentry_sdk.integrations.rq import RqIntegration
 
 
 from ckan import plugins
@@ -45,8 +46,10 @@ class SentryPlugin(plugins.SingletonPlugin):
             self._configure_logging(config)
 
         log.debug('Adding Sentry middleware...')
-        sentry_sdk.init(dsn=config.get('sentry.dsn'))
-        sentry = SentryWsgiMiddleware(app)
+        sentry_sdk.init(
+            dsn=config.get('sentry.dsn'),
+            integrations=[FlaskIntegration(), RqIntegration()]
+        )
         return app
 
     def _configure_logging(self, config):

--- a/ckanext/sentry/plugins.py
+++ b/ckanext/sentry/plugins.py
@@ -69,10 +69,14 @@ class SentryPlugin(plugins.SingletonPlugin):
 
         loggers = ['', 'ckan', 'ckanext', 'sentry.errors']
         sentry_log_level = config.get('sentry.log_level', logging.INFO)
-        for name in loggers:
-            logger = logging.getLogger(name)
-            logger.addHandler(handler)
-            logger.setLevel(sentry_log_level)
+        logger = logging.getLogger()
+        # ensure we haven't already registered the handler
+        if SentryHandler not in map(lambda x: x.__class__, logger.handlers):
+            logger.addHandler(SentryHandler())
+            # Add StreamHandler to sentry's default so you can catch missed exceptions
+            logger = logging.getLogger('sentry.errors')
+            logger.propagate = False
+            logger.addHandler(logging.StreamHandler())
 
         log.debug('Setting up Sentry logger with level {0}'.format(
             sentry_log_level))

--- a/ckanext/sentry/plugins.py
+++ b/ckanext/sentry/plugins.py
@@ -67,12 +67,12 @@ class SentryPlugin(plugins.SingletonPlugin):
         handler = SentryHandler()
         handler.setLevel(logging.NOTSET)
 
-        loggers = ['', 'ckan', 'ckanext', 'sentry.errors']
         sentry_log_level = config.get('sentry.log_level', logging.INFO)
         logger = logging.getLogger()
         # ensure we haven't already registered the handler
         if SentryHandler not in map(lambda x: x.__class__, logger.handlers):
-            logger.addHandler(SentryHandler())
+            logger.addHandler(handler)
+            logger.setLevel(sentry_log_level)
             # Add StreamHandler to sentry's default so you can catch missed exceptions
             logger = logging.getLogger('sentry.errors')
             logger.propagate = False

--- a/ckanext/sentry/plugins.py
+++ b/ckanext/sentry/plugins.py
@@ -4,8 +4,9 @@ from __future__ import unicode_literals
 import os
 import logging
 
-from raven.contrib.pylons import Sentry
-from raven.handlers.logging import SentryHandler
+import sentry_sdk
+from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
+from sentry_sdk.integrations.logging import SentryHandler
 
 
 from ckan import plugins
@@ -44,7 +45,9 @@ class SentryPlugin(plugins.SingletonPlugin):
             self._configure_logging(config)
 
         log.debug('Adding Sentry middleware...')
-        return Sentry(app, config)
+        sentry_sdk.init(dsn=config.get('sentry.dsn'))
+        sentry = SentryWsgiMiddleware(app)
+        return app
 
     def _configure_logging(self, config):
         '''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-sentry-sdk==0.7.10
+sentry-sdk==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+blinker==1.4
 sentry-sdk==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-raven==6.1.0
+sentry-sdk==0.7.10

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     namespace_packages=['ckanext'],
     include_package_data=True,
     zip_safe=False,
-    install_requires=['raven'],
+    install_requires=['sentry_sdk'],
     entry_points={
         'ckan.plugins': [
             'sentry = ckanext.sentry.plugins:SentryPlugin',


### PR DESCRIPTION
Builds on https://github.com/okfn/ckanext-sentry/pull/3, but updates sentry-sdk to the current version (1.3.1) and fixes a bug that we noticed when trying to use the version of ckanext-sentry from that pull request.